### PR TITLE
Add case to convert_date for UGE 8.2.0

### DIFF
--- a/src/glite-info-dynamic-ge
+++ b/src/glite-info-dynamic-ge
@@ -487,6 +487,14 @@ sub convert_date {
         $min   = $5;
         $sec   = $6;
     } 
+    elsif ( $date =~ m~^(\d{4})\-(\d{2})\-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})\.(\d{3})$~ ) {
+        $year  = $1;
+        $month = $2;
+        $day   = $3;
+        $hour  = $4;
+        $min   = $5;
+        $sec   = $6;
+    }
     elsif ( $date =~ m~^(\d{2})/(\d{2})/(\d{4})\s+(\d{2})\:(\d{2})\:(\d{2})$~ ) {
         $year  = $3;
         $month = $1;


### PR DESCRIPTION
UGE 8.2.0 has changed all time stamps to now report with millisecond
precision, instead of just seconds as before. This commit adds an extra
case to the convert_date function to handle this case.

https://ggus.eu/index.php?mode=ticket_info&ticket_id=109287
