### PR TITLE
Extend time_specifier values to match >1 digit per field and ignore

### DIFF
--- a/src/glite-info-dynamic-ge
+++ b/src/glite-info-dynamic-ge
@@ -1115,8 +1115,8 @@ sub to_seconds {
             return $time;
         }
     } 
-    elsif ( $time =~ /^[0-9]{1,2}:[0-9]{1,2}:[0-9]{1,2}$/ ) {
-        my @a = split( /:/, $time );
+    elsif ( $time =~ /(^[0-9]+:[0-9]+:[0-9]+)/ ) {
+        my @a = split( /:/, $1 );
         foreach my $i ( @a ) {
             $i =~ s/^0*//g;
             $i = 0 if !( $i );


### PR DESCRIPTION
per-host definitions.

Fixes #9
